### PR TITLE
Accept a list of variable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ const env = new Env();
 // read a variable and don't care if it's empty
 const username = env.get("USERNAME");
 
+// read first variable match from a list of options
+const username = env.get(["USERNAME", "LASTNAME"]);
+
 // read a variable and use a default if empty
 const username = env.get("USERNAME", "humanwhocodes");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@humanwhocodes/env",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/env.js
+++ b/src/env.js
@@ -57,12 +57,16 @@ export class Env {
      * Retrieves an environment variable without checking for its presence.
      * Optionally returns a default value if the environment variable doesn't
      * exist.
-     * @param {string} key The environment variable name to retrieve.
+     * @param {string|array} key The environment variable name or names to retrieve.
      * @param {string} [defaultValue] The default value to return if the
      *      environment variable is not found.
      * @returns {string?} The environment variable value if found or null if not.
      */
     get(key, defaultValue = null) {
+        if (Array.isArray(key)) {
+            key = key.find(k => k in this.source);
+        }
+
         return (key in this.source) ? this.source[key] : defaultValue;
     }
 

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -34,7 +34,8 @@ describe("Env", () => {
     describe("get()", () => {
 
         const source = {
-            USERNAME: "humanwhocodes"
+            USERNAME: "humanwhocodes",
+            LASTNAME: "English"
         };
 
         it("should get an environment variable when it exists", () => {
@@ -55,6 +56,29 @@ describe("Env", () => {
             assert.strictEqual(value, 123);
         });
 
+        it("should find the first environment variable requested in an array", () => {
+            const env = new Env(source);
+            const value = env.get(["USERNAME", "LASTNAME"]);
+            assert.strictEqual(value, source.USERNAME);
+        });
+
+        it("should find the first environment variable requested in an array", () => {
+            const env = new Env(source);
+            const value = env.get(["NOT_USERNAME", "USERNAME"]);
+            assert.strictEqual(value, source.USERNAME);
+        });
+
+        it("should return null when no member of the array was found", () => {
+            const env = new Env(source);
+            const value = env.get(["NOT_USERNAME", "NOT_ANYTHING"]);
+            assert.isNull(value);
+        });
+
+        it("should return default value when no member of the array was found", () => {
+            const env = new Env(source);
+            const value = env.get(["NOT_USERNAME", "NOT_ANYTHING"], 123);
+            assert.strictEqual(value, 123);
+        });
 
     });
 


### PR DESCRIPTION
I sometimes use optional environment names in the same framework or applications. Could be nice to add support here

For example
```js
const isProduction = env.get(["NODE_ENV", "RACK_ENV"], "dev").startsWith("prod")
```