### PR TITLE
Rename an incorrect variable in the last example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ const env = new Env({
 const username = env.get("USERNAME");
 
 // read a variable and throw an error if it doesn't exist
-const username = env.require("PASSWORD");
+const password = env.require("PASSWORD");
 ```
 
 [npm]: https://npmjs.com/


### PR DESCRIPTION
If you attempt to run the last example, you will get an error for redefining the `const` variable `username`.

```js
SyntaxError: redeclaration of const username
```

`username` also doesn't fit the context and seems to be a typo.