### PR TITLE
Update type for required

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -129,7 +129,7 @@ export class Env {
      * Retrieves an environment variable. If the environment variable does
      * not exist or is an empty string, then it throws an error.
      * @param {string} key The environment variable name to retrieve.
-     * @returns {string|undefined} The environment variable value.
+     * @returns {string} The environment variable value.
      * @throws {Error} When the environment variable doesn't exist or is an
      *      empty string.
      */


### PR DESCRIPTION
`env.require` would always return a value or throw. This PR corrects the typings.

Also, `env.get` should accept an overload where if the `defaultValue` is specified, it returns a string, but jsdoc doesn't really support that.