### PR TITLE
Introduce `requireMatch` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ const username = env.first(["USERNAME", "USERNAME2"], "humanwhocodes");
 // or is an empty string
 const username = env.require("USERNAME");
 
+// read a variable and throw an error if it doesn't match 
+// the provided regular expression,doesn't exist or is an 
+// empty string
+const password = env.requireMatch("PASSWORD", /^(?=.*\d).{8,}$/);
+
 // read the first found variable throw an error if none exist
 const username = env.requireFirst(["USERNAME", "USERNAME2"]);
 ```

--- a/src/env.js
+++ b/src/env.js
@@ -46,6 +46,26 @@ function emptyString(key) {
     throw new Error(`Required environment variable '${key}' is an empty string.`);
 }
 
+/**
+ * Throws an error saying that the key was not matched against a regexp.
+ * @param {string} key The key to report as not matching.
+ * @param {string} regexp The regexp which the key failed to match.
+ * @returns {void}
+ * @throws {Error} Always. 
+ */
+function regularExpressionNotMatch(key, regexp) {
+    throw new Error(`Required environment variable '${key}' must match the regular expression '${regexp}'.`);
+}
+
+/**
+ * Throws an error saying that a required regular expression was not provided.
+ * @returns {void}
+ * @throws {Error} Always. 
+ */
+function missingOrInvalidRegularExpression() {
+    throw new Error("Required regular expression was missing or invalid.");
+}
+
 //-----------------------------------------------------------------------------
 // Main
 //-----------------------------------------------------------------------------
@@ -144,6 +164,30 @@ export class Env {
             return value;
         }
     }
+
+    /**
+     * Retrieves an environment variable. If the environment variable does
+     * not exist or is an empty string, then it throws an error.
+     * @param {string} key The environment variable name to retrieve.
+     * @param {string} regexp The regular expression which the required environment variable must match against
+     * @returns {string} The environment variable value.
+     * @throws {Error} When the environment variable doesn't exist, is an
+     *      empty string or does match the provided regular expression.
+     */
+    requireMatch(key, regexp) {
+
+        if (!regexp || !(regexp instanceof RegExp)) {
+            missingOrInvalidRegularExpression();
+        }
+
+        const value = this.require(key);
+        if (value.match(regexp)) {
+            return value;
+        } else {
+            regularExpressionNotMatch(key, regexp);
+        }
+    }
+
 
     /**
      * Retrieves the first environment variable found in a list of environment

--- a/src/env.js
+++ b/src/env.js
@@ -167,9 +167,10 @@ export class Env {
 
     /**
      * Retrieves an environment variable. If the environment variable does
-     * not exist or is an empty string, then it throws an error.
+     * not match a given regular expression, doesn't exist or is an empty 
+     * string, then it throws an error.
      * @param {string} key The environment variable name to retrieve.
-     * @param {string} regexp The regular expression which the required environment variable must match against
+     * @param {RegExp} regexp The regular expression which the required environment variable must match against
      * @returns {string} The environment variable value.
      * @throws {Error} When the environment variable doesn't exist, is an
      *      empty string or does match the provided regular expression.

--- a/tests/env.test.js
+++ b/tests/env.test.js
@@ -291,4 +291,59 @@ describe("Env", () => {
 
     });
 
+    describe("requireMatch()", () => {
+        const regexp = /humanwhocodes/;
+        const source = {
+            USERNAME: "humanwhocodes",
+            OTHER: ""
+        };
+
+        it("should get an environment variable when it exists and matches a given regular expression", () => {
+            const env = new Env(source);
+            const value = env.requireMatch("USERNAME", regexp);
+            assert.strictEqual(value, source.USERNAME);
+        });
+
+        it("should throw an error when the environment variable doesn't exist", () => {
+            const env = new Env(source);
+
+            assert.throws(() => {
+                env.require("PASSWORD");
+            }, /PASSWORD/);
+        });
+
+        it("should throw an error when the environment variable is an empty string", () => {
+            const env = new Env(source);
+
+            assert.throws(() => {
+                env.require("OTHER");
+            }, /OTHER/);
+        });
+
+        it("should throw an error when the environment variable does not match the given regular expression", () => {
+            const env = new Env(source);
+
+            assert.throws(() => {
+                env.requireMatch("OTHER", regexp);
+            }, /OTHER/);
+        });
+
+        it("should throw an error when the regular expression is not provided", () => {
+            const env = new Env(source);
+
+            assert.throws(() => {
+                env.requireMatch("USERNAME");
+            }, /missing/);
+        });
+
+        it("should throw an error when the regular expression is invalid", () => {
+            const env = new Env(source);
+
+            assert.throws(() => {
+                env.requireMatch("USERNAME", "not a regexp");
+            }, /invalid/);
+        });        
+
+    });
+
 });


### PR DESCRIPTION
- This new feature requires an existing env variable to match a regular expression
- It is useful to do some basic checks on startup and prevent run time errors. An example: I started my server with the wrong AWS_REGION env. It had a random string. I could have checked against something like `^[a-z]{2}-[a-z]*-[0-9]{1}` and it would not even have started.

I wanted to ask how can I generate the correct TS type for this function. Right now it generates the type saying that the `regexp` para is a string, instead of a regexp. Any tip for me here?