### PR TITLE
Update package.json to add types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "types": "dist/env.d.ts",
   "exports": {
     "require": "./dist/env.cjs.js",
-    "import": "./dist/env.mjs"
+    "import": "./dist/env.mjs",
+    "types": "dist/env.d.ts",
   },
   "files": [
     "dist"


### PR DESCRIPTION
<img width="734" alt="Screen Shot 2023-07-09 at 5 02 26 PM" src="https://github.com/humanwhocodes/env/assets/622227/d21d350d-ad2b-4c0a-ad27-944c47b711b3">

```
Could not find a declaration file for module '@humanwhocodes/env'. '/Users/fks/Code/foo/node_modules/.pnpm/@humanwhocodes+env@2.2.2/node_modules/@humanwhocodes/env/dist/env.mjs' implicitly has an 'any' type.
  There are types at '/Users/fks/Code/foo/apps/foo/node_modules/@humanwhocodes/env/dist/env.d.ts', but this result could not be resolved when respecting package.json "exports". The '@humanwhocodes/env' library may need to update its package.json or typings.ts(7016)
```

When I installed @humanwhocodes/env in a project, I got this error from TypeScript. It looks like TypeScript now requires a "types" entry in the `exports` map if you have one. When I made this change locally, the error went away.

- `typescript@5.1.5`
- `node@18.13.0`