### PR TITLE
fix: export types for typescript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "mocha": "8.4.0",
         "rollup": "1.32.1",
         "rollup-plugin-babel-minify": "9.0.0",
-        "typescript": "4.7.4",
+        "typescript": "5.1.6",
         "yorkie": "2.0.0"
       },
       "funding": {
@@ -3578,16 +3578,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {
@@ -6613,9 +6613,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true
     },
     "uri-js": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,14 @@
   "module": "dist/env.mjs",
   "types": "dist/env.d.ts",
   "exports": {
-    "require": "./dist/env.cjs.js",
-    "import": "./dist/env.mjs"
+    "require": {
+      "default": "./dist/env.cjs.js",
+      "types": "./dist/env.d.ts"
+    },
+    "import": {
+      "default": "./dist/env.mjs",
+      "types": "./dist/env.d.ts"
+    }
   },
   "files": [
     "dist"
@@ -57,7 +63,7 @@
     "mocha": "8.4.0",
     "rollup": "1.32.1",
     "rollup-plugin-babel-minify": "9.0.0",
-    "typescript": "4.7.4",
+    "typescript": "5.1.6",
     "yorkie": "2.0.0"
   }
 }

--- a/tests/fixtures/typescript-project/package.json
+++ b/tests/fixtures/typescript-project/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "build": "tsc"
+    "prepare": "tsc -b"
   },
   "keywords": [],
   "author": "",

--- a/tests/fixtures/typescript-project/tsconfig.json
+++ b/tests/fixtures/typescript-project/tsconfig.json
@@ -1,3 +1,8 @@
 {
-    "compilerOptions": {}
+    "compilerOptions": {
+        "skipLibCheck": false,
+        "module": "NodeNext",
+        "strict": true,
+    },
+    "files": ["index.ts"]
 }

--- a/tests/pkg.test.mjs
+++ b/tests/pkg.test.mjs
@@ -5,7 +5,7 @@
 import fs from "fs";
 
 const pkg = JSON.parse(fs.readFileSync("./package.json", "utf8"));
-const url = new URL("../" + pkg.exports.import, import.meta.url);
+const url = new URL("../" + pkg.exports.import.default, import.meta.url);
 
 import(url).then(({ Env }) => {
     new Env();

--- a/tests/types.test.js
+++ b/tests/types.test.js
@@ -4,5 +4,5 @@
 /* eslint-disable no-console */
 
 const { execSync } = require("child_process");
-execSync("cd tests/fixtures/typescript-project && npm i && tsc --showConfig index.ts");
+execSync("cd tests/fixtures/typescript-project && npm i");
 console.log("env.d.ts load: success");


### PR DESCRIPTION
When TypeScript's module system is set to `NodeNext` (as [recommended](https://www.typescriptlang.org/tsconfig#module)), the types cannot be found because they are not present in the export map.

This change fixes the problem by adding the types to the export map.  Additionally:

- it reconfigures the "types" test fixture to: 
  - use `strict` mode 
  - `module: NodeNext` 
  - enables lib checking (thus validating `env.d.ts`) 
  - runs `tsc --build` on `npm install`
- updates `types.test.js` accordingly
- upgrades `typescript` to latest
- fix `pkg.test.mjs` to correctly reference the updated export map