### PR TITLE
Order package exports to make "default" the last one

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   "types": "dist/env.d.ts",
   "exports": {
     "require": {
-      "default": "./dist/env.cjs",
-      "types": "./dist/env.d.ts"
+      "types": "./dist/env.d.ts",
+      "default": "./dist/env.cjs"
     },
     "import": {
-      "default": "./dist/env.js",
-      "types": "./dist/env.d.ts"
+      "types": "./dist/env.d.ts",
+      "default": "./dist/env.js"
     }
   },
   "files": [


### PR DESCRIPTION
This fix fixes a bug that prevents webpack projects from compiling due to the mis-ordering the conditions in the package.json files.

This fix by simply reorders the default condition to make it last in the package.json file.

Allows the package to be used in next.js