### PR TITLE
chore(renovate): do not upgrade chai

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,6 +9,13 @@
     'group:linters'
   ],
   packageRules: [
+    // do not attempt to upgrade these packages to the next major.
+    // probably because they decided to go ESM-only
+    {
+      matchPackageNames: ['chai'],
+      matchUpdateTypes: ['major'],
+      enabled: false
+    }
     // only send upgrade for deps (from the npm registry) after they've been
     // published for 30 days
     {


### PR DESCRIPTION
This adds a section in the Renovate config which allows us to provide a list of packages which will not be upgraded to the next major version.

In this case, Chai v5 is ESM-only, so we will not be upgrading.