### PR TITLE
chore(renovate): fix config syntax

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -15,7 +15,7 @@
       matchPackageNames: ['chai'],
       matchUpdateTypes: ['major'],
       enabled: false
-    }
+    },
     // only send upgrade for deps (from the npm registry) after they've been
     // published for 30 days
     {


### PR DESCRIPTION
`eslint-plugin-jsonc` would have caught this
