### PR TITLE
chore(ci): drop macOS from build matrix

### DIFF
--- a/.github/workflows/nodejs-test.yml
+++ b/.github/workflows/nodejs-test.yml
@@ -4,24 +4,23 @@ on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: [windows-latest, macOS-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-latest]
         node: [16.x, 18.x, 20.x]
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: npm install, build, and test
-      run: |
-        npm install
-        npm run build --if-present
-        npm test
-      env:
-        CI: true
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: npm install, build, and test
+        run: |
+          npm install
+          npm run build --if-present
+          npm test
+        env:
+          CI: true


### PR DESCRIPTION
This package is not doing anything that should break uniquely on macOS, so running the builds there do not do much more than burn compute and wall clock time.
