### PR TITLE
ci: Fix release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,11 +7,12 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
-          release-type: 'node'
-      # The logic below handles the npm publication:
+          token: ${{secrets.GITHUB_TOKEN}}
+
+          # The logic below handles the npm publication:
       - uses: actions/checkout@v4
         # these if statements ensure that a publication only occurs when
         # a new release is created:
@@ -29,10 +30,15 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
 
       # Tweets out release announcement
-      - run: 'npx @humanwhocodes/tweet "Env v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} has been released!\n\nhttps://github.com/humanwhocodes/config-array/releases/tag/${{ steps.release.outputs.tag_name }}"'
+      - run: 'npx @humanwhocodes/crosspost -t -b -m "Env v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}.${{ steps.release.outputs.patch }} has been released!\n\nhttps://github.com/humanwhocodes/config-array/releases/tag/${{ steps.release.outputs.tag_name }}"'
         if: ${{ steps.release.outputs.release_created }}
         env:
-          TWITTER_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
-          TWITTER_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
+          TWITTER_API_CONSUMER_KEY: ${{ secrets.TWITTER_CONSUMER_KEY }}
+          TWITTER_API_CONSUMER_SECRET: ${{ secrets.TWITTER_CONSUMER_SECRET }}
           TWITTER_ACCESS_TOKEN_KEY: ${{ secrets.TWITTER_ACCESS_TOKEN_KEY }}
           TWITTER_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_ACCESS_TOKEN_SECRET }}
+          MASTODON_ACCESS_TOKEN: ${{ secrets.MASTODON_ACCESS_TOKEN }}
+          MASTODON_HOST: ${{ secrets.MASTODON_HOST }}
+          BLUESKY_IDENTIFIER: ${{ vars.BLUESKY_IDENTIFIER }}
+          BLUESKY_HOST: ${{ vars.BLUESKY_HOST }}
+          BLUESKY_PASSWORD: ${{ secrets.BLUESKY_PASSWORD }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,4 +1,5 @@
 {
+  "bootstrap-sha": "ce6ac122c2274206ae51585a17473efa9d85f72b",
   "packages": {
     ".": {
       "release-type": "node"


### PR DESCRIPTION
This pull request includes updates to the release workflow configuration and the release-please configuration file. The most important changes are adjustments to the GitHub Actions workflow for handling releases and social media announcements.

fixes #203

Updates to release workflow configuration:

* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L10-R14): Updated the action used for releases from `GoogleCloudPlatform/release-please-action` to `googleapis/release-please-action` and added the GitHub token input.
* [`.github/workflows/release-please.yml`](diffhunk://#diff-2c84033033d49186c63e6adcd705f63b11ae6814cd76c152c9c486d389fbccf3L32-R44): Changed the command used for social media announcements from `npx @humanwhocodes/tweet` to `npx @humanwhocodes/crosspost` to support multiple platforms, and updated the environment variables for Twitter and added new ones for Mastodon and Bluesky.

Updates to release-please configuration:

* [`release-please-config.json`](diffhunk://#diff-c55d4dcb68c348b2c06d263819702fbce72eeeb35b662956d02049a5a18fcf2bR2): Added a `bootstrap-sha` entry to the configuration. This resets how release-please looks for new versions. This is how I fixed the problem in another project.