### PR TITLE
chore: Disable dev dependencies in Renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -22,5 +22,12 @@
       matchDatasources: ['npm'],
       minimumReleaseAge: '30 days',
     },
+
+    // disable dev dependencies
+		{
+			matchDatasources: ["npm"],
+			matchDepTypes: ["devDependencies"],
+			enabled: false,
+		},
   ],
 }


### PR DESCRIPTION
I'm a bit annoyed at how many dev dependency PRs Renovate sends across all my repos, so I'd like to disable them. Let me know what you think.